### PR TITLE
Checksum patch

### DIFF
--- a/code/Checksum32_CMD119.java
+++ b/code/Checksum32_CMD119.java
@@ -1,0 +1,22 @@
+    /**
+    *    I'm not in the mood to explain the code.
+    **/
+    public static int calculateChecksum32(byte[] buffer) {
+        int ecx = 0; // sum
+        for (byte b : buffer) {
+            int eax = Byte.toUnsignedInt(b);
+            ecx <<= 4;
+            ecx += eax;
+            eax = ecx & 0xF0000000;
+            if (eax != 0) {
+                int edi = eax;
+                edi >>= 0x18;
+                edi = edi ^ eax;
+                ecx = ecx ^ edi;
+            }
+        }
+        long rax = Integer.toUnsignedLong(ecx) * 1077952641L;
+        int edx = (int) (rax >>> 32);
+        edx = (edx >>> 0x16) * 0x00FEFFFF;
+        return ecx - edx;
+    }

--- a/code/Checksum32_CMD119.java
+++ b/code/Checksum32_CMD119.java
@@ -1,6 +1,5 @@
-    /**
-    *    I'm not in the mood to explain the code.
-    **/
+
+
     public static int calculateChecksum32(byte[] buffer) {
         int ecx = 0; // sum
         for (byte b : buffer) {

--- a/sections/data-user.md
+++ b/sections/data-user.md
@@ -454,7 +454,7 @@ The `prep struct` indicates the size of the data to send, it has the following f
 
 (<): Little endian format.
 
-How the checksum is calculated is unknown, to check for a correct write operation, one may request the written fingerprint and apply a custom checksum to compare both templates.
+The checksum is a bit complicated to compute, check out [../code/Checksum32_CMD119.java](the code is java).
 
 The command `CMD_TMP_WRITE` seems to be the command that transfers the buffer contents to the proper location of fingerprint templates.
 

--- a/sections/data-user.md
+++ b/sections/data-user.md
@@ -454,7 +454,7 @@ The `prep struct` indicates the size of the data to send, it has the following f
 
 (<): Little endian format.
 
-The checksum is a bit complicated to compute, check out [../code/Checksum32_CMD119.java](the code is java).
+The checksum is a bit complicated to compute, check out [the code is java](../code/Checksum32_CMD119.java).
 
 The command `CMD_TMP_WRITE` seems to be the command that transfers the buffer contents to the proper location of fingerprint templates.
 


### PR DESCRIPTION
The code for the CMD_CHECKSUM_BUFFER checksum. It is used when uploading data to the device (faces, photos, fingerprints, palms...)

It must be used to check that the device has the correct data before sending the commit CMD.