### PR TITLE
fix checksum calculation code

### DIFF
--- a/protocol.md
+++ b/protocol.md
@@ -337,8 +337,9 @@ while j<len(payload):
 	# increment index by 2 bytes
 	j += 2
 
-# adds the two first bytes to the other two bytes
-chk_32b = (chk_32b & 0xffff) + ((chk_32b & 0xffff0000)>>16)
+# Fold carry bits into the lower 16 bits
+while (chk_32b &0xffff0000) != 0:
+	chk_32b = (chk_32b & 0xffff) + (chk_32b >> 16)	
 
 # calculate ones complement to get final checksum (in big endian)
 chk_16b = chk_32b ^ 0xFFFF

--- a/protocol.md
+++ b/protocol.md
@@ -338,7 +338,7 @@ while j<len(payload):
 	j += 2
 
 # Fold carry bits into the lower 16 bits
-while (chk_32b &0xffff0000) != 0:
+while (chk_32b & 0xffff0000) != 0:
 	chk_32b = (chk_32b & 0xffff) + (chk_32b >> 16)	
 
 # calculate ones complement to get final checksum (in big endian)


### PR DESCRIPTION
When summing the higher two bytes with the lower two bytes, that results sometimes to an overflow, meaning the result is bigger than 0xffff (16 bit). This way we keep folding the upper bytes until we end up with a 16 bit checksum